### PR TITLE
fix: reassign pointer to nullptr on delete

### DIFF
--- a/c_src/casbin_nif.cpp
+++ b/c_src/casbin_nif.cpp
@@ -104,6 +104,7 @@ ERL_NIF_TERM CreateEnforcer(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
 ERL_NIF_TERM DestroyEnforcer(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
   if(enforcer) delete enforcer;
+  enforcer = nullptr;
   return PF_ATOM_OK;
 }
 


### PR DESCRIPTION
fix: reassign pointer to nullptr on delete

Signed-off-by: William Michaels <bill@polarity.io>