### PR TITLE
Added line to create priv_dir in case it doesn't exist

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -57,6 +57,7 @@ defmodule Mix.Tasks.Compile.Casbin do
   end
 
   defp load_nif_path() do
+    :code.priv_dir(:casbinex)
     with {:error, :bad_name} <- :code.priv_dir(:casbinex) do
       "../../_build/#{Mix.env()}/lib/casbinex/priv/casbinex_nif.so"
     else


### PR DESCRIPTION
So it turns out the reason for the `:bad_name` error is coming from the `priv` directory not existing during compilation, as it is during the compilation that the `priv` is created that we are using `:code.priv_dir(:casbinex)`.  Turns out if you run `:code.priv_dir(:casbinex)` though, it just creates the `priv` folder in the correct place regardless of whether you are on windows or mac or in what folder/subfolder you run compilation from :raised_hands:, so just running it one time before you actually need to use it makes it so the folder is created and you don't get the `:bad_name` error.