### PR TITLE
makefile - handle multiple mac arch, multiple erl install dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 MIX = mix
 CFLAGS += --std=c++17
 
-ERLANG_PATH = $(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/erts-", erlang:system_info(version), "/include"])])' -s init stop -noshell)
-CFLAGS += -Ic_src/include -I$(ERLANG_PATH)
+PRIV = priv
+
+ERLANG_INCLUDE_PATH = $(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/erts-", erlang:system_info(version), "/include"])])' -s init stop -noshell)
+ERLANG_LIB_PATH =$(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/lib"])])' -s init stop -noshell)
+
+CFLAGS += -Ic_src/include -I$(ERLANG_INCLUDE_PATH)
 
 ifeq ($(wildcard deps/casbinex),)
 	CASBINEX_PATH = ../casbinex
@@ -14,8 +18,15 @@ ifneq ($(OS),Windows_NT)
 	LDFLAGS += c_src/casbin_nif.cpp c_src/pg_adapter.cpp c_src/pg_pool.cpp
 
 	ifeq ($(shell uname),Darwin)
-		CFLAGS += -Ic_src/macos/include -I/usr/local/lib/erlang/usr/include/ -L/usr/local/opt/libpq/lib
-		CFLAGS += -fPIC -O3 -Lc_src/macos/lib -L/usr/local/opt/libpq/lib -L/usr/local/opt/erlang/lib/erlang/lib -dynamiclib
+
+		ifeq ($(shell uname -m), arm64)
+		  HOMEBREW_PREFIX = /opt/homebrew
+		else
+		  HOMEBREW_PREFIX = /usr/local
+		endif
+
+		CFLAGS += -Ic_src/macos/include -I$(ERLANG_INCLUDE_PATH) -L$(HOMEBREW_PREFIX)/opt/libpq/lib
+		CFLAGS += -fPIC -O3 -Lc_src/macos/lib -L$(HOMEBREW_PREFIX)/opt/libpq/lib -L$(ERLANG_LIB_PATH) -dynamiclib
 		LDFLAGS += c_src/macos/lib/casbin.a -lpqxx -lpq -flat_namespace -undefined suppress
 	else
 		CFLAGS += -Ic_src/linux/include -Lc_src/linux/lib -fPIC -O3
@@ -25,8 +36,9 @@ endif
 
 .PHONY: all casbinex clean
 
-all: 
-	$(MIX) compile 
+all:
+	[ -d $(PRIV) ] || mkdir -p $(PRIV)
+	$(MIX) compile
 
 priv/casbinex_nif.so:
 	/usr/bin/g++ $(CFLAGS) -shared -o $@ $(LDFLAGS)


### PR DESCRIPTION
The following commands
```
$(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/erts-", erlang:system_info(version), "/include"])])' -s init stop -noshell)
```
```
$(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/lib"])])' -s    nit stop -noshell)
```

return the respective paths for each method of erlang installation

> brew

```
/opt/homebrew/Cellar/erlang/24.1.7/lib/erlang/erts-12.1.5/include
/opt/homebrew/Cellar/erlang/24.1.7/lib/erlang/lib
```

> asdf

```
/Users/joshmix/.asdf/installs/erlang/24.0.4/erts-12.0.3/include
/Users/joshmix/.asdf/installs/erlang/24.0.4/lib
```